### PR TITLE
Set MSRV to 1.59.0 in Cargo.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.57.0
+          - 1.59.0
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -44,7 +44,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.57.0
+          - 1.59.0
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -63,7 +63,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.57.0
+          - 1.59.0
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -84,7 +84,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.57.0
+          - 1.59.0
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/rpm-rs/rpm-rs"
 readme = "README.md"
 keywords = ["RPM", "packaging"]
 categories = ["parsing", "development-tools"]
-rust-version = "1.57.0"
+rust-version = "1.59.0"
 
 [lib]
 name = "rpm"


### PR DESCRIPTION
Currently,
- `rpm-rs` depends on `rsa-der ^0.3.0`
- `rsa-der 0.3.0` depends on `simple_asn1 ^0.6`
- `simple_asn1 0.6.2` depends on `time ^0.3`
- `time 0.3.14` specifies MSRV `1.59.0`

This commit fixes the following error with Rust 1.57.0 (occurs in CI):
> error: package `time v0.3.14` cannot be built because it requires rustc 1.59.0 or newer, while the currently active rustc version is 1.57.0
