### PR TITLE
Add explicit hardlink sets to PackageBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `FileOptionsBuilder::hardlink()` declares exact package-local hardlink sets. The builder validates member content and metadata, emits shared header inode/device authority, and writes one completing payload member with the RPM hardlink link count.
+- `FileOptionsBuilder::hardlink()` declares package-local hardlink sets.
 - The optional `signature-sequoia` feature provides OpenPGP signing and verification through Sequoia 2.3's pure-Rust crypto backend. Signature backends are mutually exclusive: select Sequoia with `--no-default-features --features signature-sequoia`. The default remains `signature-pgp`, including its draft-PQC support.
 
 ## 0.27.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `FileOptionsBuilder::hardlink()` declares exact package-local hardlink sets. The builder validates member content and metadata, emits shared header inode/device authority, and writes one completing payload member with the RPM hardlink link count.
 - The optional `signature-sequoia` feature provides OpenPGP signing and verification through Sequoia 2.3's pure-Rust crypto backend. Signature backends are mutually exclusive: select Sequoia with `--no-default-features --features signature-sequoia`. The default remains `signature-pgp`, including its draft-PQC support.
 
 ## 0.27.1

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 
+mod hardlinks;
+
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::convert::TryInto;
 use std::io::Read;
@@ -894,6 +896,22 @@ impl PackageBuilder {
             options.mode.set_permissions(perms);
         }
 
+        if options.hardlink_identity.as_deref() == Some("") {
+            return Err(Error::InvalidFileOptions {
+                method: "FileOptionsBuilder::hardlink",
+                reason: "hardlink identity must not be empty",
+            });
+        }
+        if options.hardlink_identity.is_some()
+            && (options.mode.file_type() != FileType::Regular
+                || options.flag.contains(FileFlags::GHOST))
+        {
+            return Err(Error::InvalidFileOptions {
+                method: "FileOptionsBuilder::hardlink",
+                reason: "hardlink identity is only valid for non-ghost regular files",
+            });
+        }
+
         let dest = options.destination;
         if !dest.starts_with("./") && !dest.starts_with('/') {
             return Err(Error::InvalidDestinationPath {
@@ -987,6 +1005,7 @@ impl PackageBuilder {
             dir: dir.clone(),
             caps: options.caps,
             verify_flags: options.verify_flags,
+            hardlink_identity: options.hardlink_identity,
             bulk_added: bulk,
         };
 
@@ -1509,6 +1528,7 @@ impl PackageBuilder {
     /// @todo split this into multiple `fn`s, one per `IndexTag`-group.
     fn prepare_data(mut self) -> Result<(Lead, Header<IndexTag>, Vec<u8>), Error> {
         self.pre_build_validation()?;
+        let hardlinks = hardlinks::Plan::from_files(&self.files)?;
 
         // signature depends on header and payload. So we build these two first.
         // then the signature. Then we stitch all together.
@@ -1545,13 +1565,10 @@ impl PackageBuilder {
         let mut base_names = Vec::with_capacity(files_len);
         let mut users_to_create = HashSet::new();
         let mut groups_to_create = HashSet::new();
+        let mut resolved_mtimes = Vec::with_capacity(files_len);
 
-        let mut combined_file_sizes: u64 = 0;
         let mut uses_file_capabilities = false;
-
-        for entry in self.files.values() {
-            combined_file_sizes += entry.source.size()?;
-        }
+        let combined_file_sizes = hardlinks.installed_size(&self.files)?;
 
         let uses_large_files =
             combined_file_sizes > u32::MAX.into() || self.config.format != RpmFormat::V4;
@@ -1559,7 +1576,7 @@ impl PackageBuilder {
         // Entries are sorted by path (BTreeMap iteration order) and duplicates are rejected
         // in add_data(). Paths are also normalized there (collapsing slashes, stripping trailing
         // slashes) to ensure deduplication works correctly.
-        for (file_index, (cpio_path, entry)) in self.files.iter_mut().enumerate() {
+        for (cpio_path, entry) in self.files.iter_mut() {
             if entry.caps.is_some() {
                 uses_file_capabilities = true;
             }
@@ -1586,11 +1603,15 @@ impl PackageBuilder {
                 _ => entry.modified_at,
             };
             file_mtimes.push(mtime.into());
+            resolved_mtimes.push(mtime);
             file_linktos.push(entry.link.to_owned());
             file_flags.push(entry.flags.bits());
             file_usernames.push(entry.user.to_owned());
             file_groupnames.push(entry.group.to_owned());
-            file_inodes.push(ino_index);
+            let inode = hardlinks
+                .member(cpio_path)
+                .map_or(ino_index, |member| member.inode);
+            file_inodes.push(inode);
             file_langs.push("".to_string());
             // safe because indexes cannot change after this as the RpmBuilder is consumed
             // the dir is guaranteed to be there - or else there is a logic error
@@ -1621,33 +1642,51 @@ impl PackageBuilder {
                 continue;
             }
 
-            let mut writer = if !uses_large_files {
-                payload::Builder::new(cpio_path)
-                    .mode(entry.mode.into())
-                    .ino(ino_index)
-                    .nlink(1)
-                    .mtime(mtime.into())
-                    .uid(self.uid.unwrap_or(0))
-                    .gid(self.gid.unwrap_or(0))
-                    .write_cpio(&mut archive, entry.source.size()? as u32)
-            } else {
-                payload::write_stripped_cpio(&mut archive, file_index as u32, entry.source.size()?)
-            };
-            // Only regular files have digests; dirs and symlinks get empty strings
+            // Only regular files have digests; dirs and symlinks get empty strings.
+            // Content is written in a second phase so hardlink sets can follow RPM's
+            // archive ordering and carry bytes only on their completing member.
             if entry.mode.file_type() == FileType::Regular {
-                let mut hash_writer = ChecksummingWriter::new(&mut writer, &[HashKind::Sha256]);
+                let mut sink = io::sink();
+                let mut hash_writer = ChecksummingWriter::new(&mut sink, &[HashKind::Sha256]);
                 io::copy(&mut entry.source.try_into_bufread()?, &mut hash_writer)?;
                 let hash_value_map = hash_writer.into_digests().0;
-                writer.finish()?;
                 if let Some(hash_value) = hash_value_map.get(&HashKind::Sha256) {
                     file_hashes.push(hash_value.to_string());
                 }
             } else {
-                io::copy(&mut entry.source.try_into_bufread()?, &mut writer)?;
-                writer.finish()?;
                 file_hashes.push(String::new());
             }
             ino_index += 1;
+        }
+
+        let file_keys = self.files.keys().cloned().collect::<Vec<_>>();
+        for cpio_path in hardlinks.payload_order(&self.files) {
+            let file_index = file_keys
+                .binary_search(&cpio_path)
+                .expect("payload path came from sorted package file map");
+            let entry = &self.files[&cpio_path];
+            let member = hardlinks.member(&cpio_path);
+            let payload_size = if member.is_none_or(|member| member.has_content) {
+                entry.source.size()?
+            } else {
+                0
+            };
+            let mut writer = if !uses_large_files {
+                payload::Builder::new(&cpio_path)
+                    .mode(entry.mode.into())
+                    .ino(member.map_or(file_inodes[file_index], |member| member.inode))
+                    .nlink(member.map_or(1, |member| member.link_count))
+                    .mtime(resolved_mtimes[file_index].into())
+                    .uid(self.uid.unwrap_or(0))
+                    .gid(self.gid.unwrap_or(0))
+                    .write_cpio(&mut archive, payload_size as u32)
+            } else {
+                payload::write_stripped_cpio(&mut archive, file_index as u32, payload_size)
+            };
+            if payload_size > 0 {
+                io::copy(&mut entry.source.try_into_bufread()?, &mut writer)?;
+            }
+            writer.finish()?;
         }
         payload::trailer(&mut archive)?;
 

--- a/src/rpm/builder/hardlinks.rs
+++ b/src/rpm/builder/hardlinks.rs
@@ -1,0 +1,146 @@
+//! Exact hardlink-set planning for RPM package construction.
+
+use std::collections::{BTreeMap, HashMap};
+use std::io::Read;
+
+use sha2::{Digest, Sha256};
+
+use super::PackageFileEntry;
+use crate::Error;
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct Member {
+    pub(super) inode: u32,
+    pub(super) link_count: u32,
+    pub(super) has_content: bool,
+}
+
+#[derive(Default)]
+pub(super) struct Plan {
+    members: HashMap<String, Member>,
+}
+
+impl Plan {
+    pub(super) fn from_files(files: &BTreeMap<String, PackageFileEntry>) -> Result<Self, Error> {
+        let mut groups = BTreeMap::<&str, Vec<(&str, &PackageFileEntry)>>::new();
+        for (path, entry) in files {
+            if let Some(identity) = entry.hardlink_identity.as_deref() {
+                groups.entry(identity).or_default().push((path, entry));
+            }
+        }
+
+        let mut members = HashMap::new();
+        for entries in groups.values() {
+            validate_group(entries)?;
+            let inode = files
+                .keys()
+                .position(|candidate| candidate == entries[0].0)
+                .expect("hardlink member came from package file map")
+                .checked_add(1)
+                .and_then(|value| u32::try_from(value).ok())
+                .ok_or(Error::InvalidFileOptions {
+                    method: "PackageBuilder::build",
+                    reason: "hardlink inode exceeds RPM's 32-bit authority",
+                })?;
+            let link_count =
+                u32::try_from(entries.len()).map_err(|_| Error::InvalidFileOptions {
+                    method: "PackageBuilder::build",
+                    reason: "hardlink set exceeds RPM's 32-bit link-count authority",
+                })?;
+            for (index, (path, _)) in entries.iter().enumerate() {
+                members.insert(
+                    (*path).to_string(),
+                    Member {
+                        inode,
+                        link_count,
+                        has_content: index + 1 == entries.len(),
+                    },
+                );
+            }
+        }
+        Ok(Self { members })
+    }
+
+    pub(super) fn member(&self, path: &str) -> Option<Member> {
+        self.members.get(path).copied()
+    }
+
+    pub(super) fn payload_order(&self, files: &BTreeMap<String, PackageFileEntry>) -> Vec<String> {
+        files
+            .iter()
+            .filter(|(_, entry)| !entry.flags.contains(crate::FileFlags::GHOST))
+            .filter(|(path, _)| !self.members.contains_key(path.as_str()))
+            .chain(
+                files
+                    .iter()
+                    .filter(|(_, entry)| !entry.flags.contains(crate::FileFlags::GHOST))
+                    .filter(|(path, _)| self.members.contains_key(path.as_str())),
+            )
+            .map(|(path, _)| path.clone())
+            .collect()
+    }
+
+    pub(super) fn installed_size(
+        &self,
+        files: &BTreeMap<String, PackageFileEntry>,
+    ) -> Result<u64, Error> {
+        files.iter().try_fold(0_u64, |total, (path, entry)| {
+            let contributes = self.member(path).is_none_or(|member| member.has_content);
+            let size = if contributes { entry.source.size()? } else { 0 };
+            total.checked_add(size).ok_or(Error::InvalidFileOptions {
+                method: "PackageBuilder::build",
+                reason: "combined installed size exceeds RPM's 64-bit authority",
+            })
+        })
+    }
+}
+
+fn validate_group(entries: &[(&str, &PackageFileEntry)]) -> Result<(), Error> {
+    if entries.len() < 2 {
+        return Err(Error::InvalidFileOptions {
+            method: "PackageBuilder::build",
+            reason: "hardlink identity must name at least two package files",
+        });
+    }
+    let anchor = entries[0].1;
+    let anchor_size = anchor.source.size()?;
+    let anchor_digest = content_digest(anchor)?;
+    for (_, member) in &entries[1..] {
+        if member.mode != anchor.mode
+            || member.modified_at != anchor.modified_at
+            || member.user != anchor.user
+            || member.group != anchor.group
+            || member.flags != anchor.flags
+            || member.verify_flags != anchor.verify_flags
+            || member.link != anchor.link
+            || member.caps.as_ref().map(ToString::to_string)
+                != anchor.caps.as_ref().map(ToString::to_string)
+        {
+            return Err(Error::InvalidFileOptions {
+                method: "PackageBuilder::build",
+                reason: "hardlink members must have identical effective metadata",
+            });
+        }
+        if member.source.size()? != anchor_size || content_digest(member)? != anchor_digest {
+            return Err(Error::InvalidFileOptions {
+                method: "PackageBuilder::build",
+                reason: "hardlink members must have identical content",
+            });
+        }
+    }
+    Ok(())
+}
+
+fn content_digest(entry: &PackageFileEntry) -> Result<[u8; 32], Error> {
+    let mut reader = entry.source.try_into_bufread()?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let count = reader.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+    Ok(hasher.finalize().into())
+}

--- a/src/rpm/builder/hardlinks.rs
+++ b/src/rpm/builder/hardlinks.rs
@@ -8,13 +8,18 @@ use sha2::{Digest, Sha256};
 use super::PackageFileEntry;
 use crate::Error;
 
+/// The RPM header and payload properties assigned to one declared hardlink member.
 #[derive(Clone, Copy, Debug)]
 pub(super) struct Member {
+    /// Synthetic inode shared by every member of the set.
     pub(super) inode: u32,
+    /// Number of paths in the complete package-local set.
     pub(super) link_count: u32,
+    /// Whether this member carries the set's bytes in the CPIO payload.
     pub(super) has_content: bool,
 }
 
+/// Validated hardlink properties indexed by normalized package path.
 #[derive(Default)]
 pub(super) struct Plan {
     members: HashMap<String, Member>,
@@ -22,6 +27,8 @@ pub(super) struct Plan {
 
 impl Plan {
     pub(super) fn from_files(files: &BTreeMap<String, PackageFileEntry>) -> Result<Self, Error> {
+        // Group declarations by their caller-owned identity. BTreeMap ordering makes both
+        // group traversal and member order deterministic across builder invocations.
         let mut groups = BTreeMap::<&str, Vec<(&str, &PackageFileEntry)>>::new();
         for (path, entry) in files {
             if let Some(identity) = entry.hardlink_identity.as_deref() {
@@ -32,6 +39,9 @@ impl Plan {
         let mut members = HashMap::new();
         for entries in groups.values() {
             validate_group(entries)?;
+
+            // RPM identifies files by their one-based position in the sorted header arrays.
+            // Every member receives the position of the set's first package path.
             let inode = files
                 .keys()
                 .position(|candidate| candidate == entries[0].0)
@@ -47,6 +57,9 @@ impl Plan {
                     method: "PackageBuilder::build",
                     reason: "hardlink set exceeds RPM's 32-bit link-count authority",
                 })?;
+
+            // In an RPM CPIO payload, earlier hardlink entries have zero size and the final
+            // entry carries the shared bytes. `entries` is already in package-path order.
             for (index, (path, _)) in entries.iter().enumerate() {
                 members.insert(
                     (*path).to_string(),
@@ -66,6 +79,8 @@ impl Plan {
     }
 
     pub(super) fn payload_order(&self, files: &BTreeMap<String, PackageFileEntry>) -> Vec<String> {
+        // Match rpmbuild: ordinary payload entries come first, followed by all hardlink
+        // members. Each partition retains the package's sorted header order.
         files
             .iter()
             .filter(|(_, entry)| !entry.flags.contains(crate::FileFlags::GHOST))
@@ -84,6 +99,8 @@ impl Plan {
         &self,
         files: &BTreeMap<String, PackageFileEntry>,
     ) -> Result<u64, Error> {
+        // Hardlink paths report the shared file size individually in RPMTAG_FILESIZES, but
+        // RPMTAG_SIZE counts their installed bytes only once.
         files.iter().try_fold(0_u64, |total, (path, entry)| {
             let contributes = self.member(path).is_none_or(|member| member.has_content);
             let size = if contributes { entry.source.size()? } else { 0 };
@@ -106,6 +123,8 @@ fn validate_group(entries: &[(&str, &PackageFileEntry)]) -> Result<(), Error> {
     let anchor_size = anchor.source.size()?;
     let anchor_digest = content_digest(anchor)?;
     for (_, member) in &entries[1..] {
+        // One filesystem inode cannot give its paths different ownership, mode, flags,
+        // timestamps, link targets, capabilities, or verification policy.
         if member.mode != anchor.mode
             || member.modified_at != anchor.modified_at
             || member.user != anchor.user
@@ -121,6 +140,8 @@ fn validate_group(entries: &[(&str, &PackageFileEntry)]) -> Result<(), Error> {
                 reason: "hardlink members must have identical effective metadata",
             });
         }
+        // Compare both size and a streaming digest so declarations work for raw buffers and
+        // file-backed content without retaining every member's bytes in memory.
         if member.source.size()? != anchor_size || content_digest(member)? != anchor_digest {
             return Err(Error::InvalidFileOptions {
                 method: "PackageBuilder::build",

--- a/src/rpm/builder/hardlinks.rs
+++ b/src/rpm/builder/hardlinks.rs
@@ -144,3 +144,90 @@ fn content_digest(entry: &PackageFileEntry) -> Result<[u8; 32], Error> {
     }
     Ok(hasher.finalize().into())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::ContentSource;
+    use super::*;
+    use crate::{FileFlags, FileMode, FileVerifyFlags, Timestamp};
+
+    fn entry(content: &str, identity: Option<&str>) -> PackageFileEntry {
+        PackageFileEntry {
+            mode: FileMode::regular(0o644),
+            modified_at: Timestamp(7),
+            link: String::new(),
+            flags: FileFlags::empty(),
+            user: "root".to_string(),
+            group: "root".to_string(),
+            base_name: String::new(),
+            dir: "/".to_string(),
+            caps: None,
+            verify_flags: FileVerifyFlags::ALL_FLAGS,
+            source: ContentSource::Raw(content.as_bytes().to_vec()),
+            hardlink_identity: identity.map(str::to_string),
+            bulk_added: false,
+        }
+    }
+
+    #[test]
+    fn plans_shared_identity_and_rpm_payload_order() {
+        let files = BTreeMap::from([
+            ("./alpha-1".to_string(), entry("alpha", Some("alpha"))),
+            ("./alpha-2".to_string(), entry("alpha", Some("alpha"))),
+            ("./beta-1".to_string(), entry("beta", Some("beta"))),
+            ("./beta-2".to_string(), entry("beta", Some("beta"))),
+            ("./standalone".to_string(), entry("alone", None)),
+        ]);
+
+        let plan = Plan::from_files(&files).unwrap();
+        let alpha_1 = plan.member("./alpha-1").unwrap();
+        let alpha_2 = plan.member("./alpha-2").unwrap();
+        let beta_1 = plan.member("./beta-1").unwrap();
+        let beta_2 = plan.member("./beta-2").unwrap();
+
+        assert_eq!(alpha_1.inode, 1);
+        assert_eq!(alpha_2.inode, alpha_1.inode);
+        assert_eq!(alpha_1.link_count, 2);
+        assert!(!alpha_1.has_content);
+        assert!(alpha_2.has_content);
+        assert_eq!(beta_1.inode, 3);
+        assert_eq!(beta_2.inode, beta_1.inode);
+        assert!(plan.member("./standalone").is_none());
+        assert_eq!(
+            plan.payload_order(&files),
+            [
+                "./standalone",
+                "./alpha-1",
+                "./alpha-2",
+                "./beta-1",
+                "./beta-2",
+            ]
+        );
+        assert_eq!(plan.installed_size(&files).unwrap(), 14);
+    }
+
+    #[test]
+    fn rejects_incomplete_or_conflicting_sets() {
+        let incomplete =
+            BTreeMap::from([("./only".to_string(), entry("same", Some("incomplete")))]);
+        assert!(
+            Plan::from_files(&incomplete)
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("at least two package files")
+        );
+
+        let conflicting = BTreeMap::from([
+            ("./first".to_string(), entry("first", Some("conflict"))),
+            ("./second".to_string(), entry("second", Some("conflict"))),
+        ]);
+        assert!(
+            Plan::from_files(&conflicting)
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("identical content")
+        );
+    }
+}

--- a/src/rpm/headers/types.rs
+++ b/src/rpm/headers/types.rs
@@ -167,6 +167,8 @@ mod build_types {
         pub caps: Option<FileCaps>,
         pub verify_flags: FileVerifyFlags,
         pub source: ContentSource,
+        /// Explicit package-local identity shared by members of one hardlink set.
+        pub(crate) hardlink_identity: Option<String>,
         /// Whether this entry was added by a bulk operation (e.g. `with_dir`).
         /// Bulk-added entries can be replaced by explicit methods like `with_file`.
         pub(crate) bulk_added: bool,
@@ -185,6 +187,7 @@ mod build_types {
         pub(crate) use_default_permissions: bool,
         pub(crate) caps: Option<FileCaps>,
         pub(crate) verify_flags: FileVerifyFlags,
+        pub(crate) hardlink_identity: Option<String>,
     }
 
     impl FileOptions {
@@ -205,6 +208,7 @@ mod build_types {
                     use_default_permissions: true,
                     caps: None,
                     verify_flags: FileVerifyFlags::ALL_FLAGS,
+                    hardlink_identity: None,
                 },
             }
         }
@@ -227,6 +231,7 @@ mod build_types {
                     use_default_permissions: true,
                     caps: None,
                     verify_flags: FileVerifyFlags::ALL_FLAGS,
+                    hardlink_identity: None,
                 },
             }
         }
@@ -251,6 +256,7 @@ mod build_types {
                     use_default_permissions: false,
                     caps: None,
                     verify_flags: FileVerifyFlags::ALL_FLAGS,
+                    hardlink_identity: None,
                 },
             }
         }
@@ -282,6 +288,7 @@ mod build_types {
                             | FileVerifyFlags::FILESIZE
                             | FileVerifyFlags::LINKTO
                             | FileVerifyFlags::MTIME),
+                    hardlink_identity: None,
                 },
             }
         }
@@ -306,6 +313,7 @@ mod build_types {
                     use_default_permissions: true,
                     caps: None,
                     verify_flags: FileVerifyFlags::ALL_FLAGS,
+                    hardlink_identity: None,
                 },
             }
         }
@@ -317,6 +325,16 @@ mod build_types {
     }
 
     impl FileOptionsBuilder {
+        /// Associate this regular file with an explicitly declared hardlink set.
+        ///
+        /// Every set identity must be used by at least two regular files. Members
+        /// must have identical content and effective metadata. The identity is
+        /// package-local builder authority and is not stored in the RPM itself.
+        pub fn hardlink(mut self, identity: impl Into<String>) -> Self {
+            self.inner.hardlink_identity = Some(identity.into());
+            self
+        }
+
         /// Indicates that the file should be owned by the specified username.
         ///
         /// Specifying a non-root user here will direct RPM to create the user via sysusers.d at

--- a/tests/building.rs
+++ b/tests/building.rs
@@ -882,3 +882,112 @@ fn test_epoch_handling() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[test]
+fn explicit_hardlink_set_shares_header_identity_and_one_payload()
+-> Result<(), Box<dyn std::error::Error>> {
+    let content = b"shared hardlink content";
+    let package = PackageBuilder::new("hardlinks", "1.0", "MIT", "noarch", "hardlink test")
+        .with_file_contents(
+            content,
+            FileOptions::new("/usr/lib/hardlinks/anchor")
+                .permissions(0o640)
+                .hardlink("payload:shared"),
+        )?
+        .with_file_contents(
+            content,
+            FileOptions::new("/usr/lib/hardlinks/alias")
+                .permissions(0o640)
+                .hardlink("payload:shared"),
+        )?
+        .build()?;
+
+    let inodes = package
+        .metadata
+        .header
+        .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILEINODES)?;
+    let devices = package
+        .metadata
+        .header
+        .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILEDEVICES)?;
+    let sizes = package
+        .metadata
+        .header
+        .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILESIZES)?;
+    let digests = package
+        .metadata
+        .header
+        .get_entry_data_as_string_array(IndexTag::RPMTAG_FILEDIGESTS)?;
+    assert_eq!(inodes.len(), 2);
+    assert_eq!(inodes[0], inodes[1]);
+    assert_eq!(devices, vec![1, 1]);
+    assert_eq!(sizes, vec![content.len() as u32; 2]);
+    assert_eq!(digests[0], digests[1]);
+
+    let files = package.files()?.collect::<Result<Vec<_>, _>>()?;
+    assert_eq!(files.len(), 2);
+    assert!(files[0].content.is_empty());
+    assert_eq!(files[1].content, content);
+    Ok(())
+}
+
+#[test]
+fn explicit_hardlink_set_rejects_partial_or_incompatible_members() {
+    let partial = PackageBuilder::new("hardlinks", "1.0", "MIT", "noarch", "hardlink test")
+        .with_file_contents(
+            "same",
+            FileOptions::new("/anchor").hardlink("payload:partial"),
+        )
+        .unwrap()
+        .build();
+    assert!(
+        partial
+            .unwrap_err()
+            .to_string()
+            .contains("at least two package files")
+    );
+
+    let content_mismatch =
+        PackageBuilder::new("hardlinks", "1.0", "MIT", "noarch", "hardlink test")
+            .with_file_contents(
+                "first",
+                FileOptions::new("/anchor").hardlink("payload:content"),
+            )
+            .unwrap()
+            .with_file_contents(
+                "second",
+                FileOptions::new("/alias").hardlink("payload:content"),
+            )
+            .unwrap()
+            .build();
+    assert!(
+        content_mismatch
+            .unwrap_err()
+            .to_string()
+            .contains("identical content")
+    );
+
+    let metadata_mismatch =
+        PackageBuilder::new("hardlinks", "1.0", "MIT", "noarch", "hardlink test")
+            .with_file_contents(
+                "same",
+                FileOptions::new("/anchor")
+                    .permissions(0o640)
+                    .hardlink("payload:metadata"),
+            )
+            .unwrap()
+            .with_file_contents(
+                "same",
+                FileOptions::new("/alias")
+                    .permissions(0o600)
+                    .hardlink("payload:metadata"),
+            )
+            .unwrap()
+            .build();
+    assert!(
+        metadata_mismatch
+            .unwrap_err()
+            .to_string()
+            .contains("identical effective metadata")
+    );
+}

--- a/tests/building.rs
+++ b/tests/building.rs
@@ -883,6 +883,8 @@ fn test_epoch_handling() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Verify an explicit hardlink set receives one shared RPM inode and link count,
+/// with its content carried only by the set's completing payload member.
 #[test]
 fn explicit_hardlink_set_shares_header_identity_and_one_payload()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -931,6 +933,8 @@ fn explicit_hardlink_set_shares_header_identity_and_one_payload()
     Ok(())
 }
 
+/// Reject incomplete hardlink sets and members whose content or effective
+/// metadata differs, since they cannot represent one installed filesystem inode.
 #[test]
 fn explicit_hardlink_set_rejects_partial_or_incompatible_members() {
     let partial = PackageBuilder::new("hardlinks", "1.0", "MIT", "noarch", "hardlink test")

--- a/tests/compare.rs
+++ b/tests/compare.rs
@@ -824,11 +824,17 @@ fn test_build_rpm_rich_deps() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Build a package matching the rpm-hardlinks.spec file.
+///
+/// Tests explicit hardlink declaration and payload deduplication:
+/// - Three hardlinked files (alpha-1, alpha-2, alpha-3) sharing content
+/// - Two hardlinked files (beta-1, beta-2) sharing content
+/// - One standalone file
 #[test]
 fn test_build_rpm_hardlinks() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = std::env::temp_dir().join("rpm-rs-explicit-hardlinks-test");
     std::fs::create_dir_all(&temp_dir)?;
 
+    // Create files with hardlinks.
     let alpha_1 = temp_dir.join("alpha-1");
     std::fs::write(&alpha_1, "shared-content-alpha\n")?;
     let alpha_2 = temp_dir.join("alpha-2");
@@ -901,11 +907,15 @@ fn test_build_rpm_hardlinks() -> Result<(), Box<dyn std::error::Error>> {
     )?
     .build()?;
 
+    // Clean up.
     std::fs::remove_dir_all(&temp_dir)?;
 
+    // Write and re-read the package.
     let mut buf = Vec::new();
     pkg.write(&mut buf)?;
     let parsed = Package::parse(&mut buf.as_slice())?;
+
+    // Compare with the rpmbuild fixture package.
     let fixture = Package::open(common::pkgs::v6::RPM_HARDLINKS)?;
     assert_packages_match(&parsed, &fixture, "v6")?;
 

--- a/tests/compare.rs
+++ b/tests/compare.rs
@@ -823,6 +823,95 @@ fn test_build_rpm_rich_deps() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Build a package matching the rpm-hardlinks.spec file.
+#[test]
+fn test_build_rpm_hardlinks() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = std::env::temp_dir().join("rpm-rs-explicit-hardlinks-test");
+    std::fs::create_dir_all(&temp_dir)?;
+
+    let alpha_1 = temp_dir.join("alpha-1");
+    std::fs::write(&alpha_1, "shared-content-alpha\n")?;
+    let alpha_2 = temp_dir.join("alpha-2");
+    let _ = std::fs::remove_file(&alpha_2);
+    std::fs::hard_link(&alpha_1, &alpha_2)?;
+    let alpha_3 = temp_dir.join("alpha-3");
+    let _ = std::fs::remove_file(&alpha_3);
+    std::fs::hard_link(&alpha_1, &alpha_3)?;
+
+    let beta_1 = temp_dir.join("beta-1");
+    std::fs::write(&beta_1, "shared-content-beta\n")?;
+    let beta_2 = temp_dir.join("beta-2");
+    let _ = std::fs::remove_file(&beta_2);
+    std::fs::hard_link(&beta_1, &beta_2)?;
+
+    let standalone = temp_dir.join("standalone");
+    std::fs::write(&standalone, "standalone\n")?;
+
+    let pkg = PackageBuilder::new(
+        "rpm-hardlinks",
+        "1.0",
+        "MIT",
+        "noarch",
+        "Test RPM hard link handling",
+    )
+    .using_config(
+        BuildConfig::v6()
+            .compression(CompressionType::None)
+            .source_date(common::FIXTURE_SOURCE_DATE),
+    )
+    .release("1")
+    .description(
+        "A package for exercising RPM hard link handling in the payload.\n\
+         Contains sets of hard-linked files to test inode deduplication\n\
+         and the RPMTAG_FILEINODES / RPMTAG_FILENLINKS tags.",
+    )
+    .with_file(
+        &alpha_1,
+        FileOptions::new("/opt/rpm-hardlinks/alpha-1")
+            .permissions(0o644)
+            .hardlink("alpha"),
+    )?
+    .with_file(
+        &alpha_2,
+        FileOptions::new("/opt/rpm-hardlinks/alpha-2")
+            .permissions(0o644)
+            .hardlink("alpha"),
+    )?
+    .with_file(
+        &alpha_3,
+        FileOptions::new("/opt/rpm-hardlinks/alpha-3")
+            .permissions(0o644)
+            .hardlink("alpha"),
+    )?
+    .with_file(
+        &beta_1,
+        FileOptions::new("/opt/rpm-hardlinks/beta-1")
+            .permissions(0o644)
+            .hardlink("beta"),
+    )?
+    .with_file(
+        &beta_2,
+        FileOptions::new("/opt/rpm-hardlinks/beta-2")
+            .permissions(0o644)
+            .hardlink("beta"),
+    )?
+    .with_file(
+        &standalone,
+        FileOptions::new("/opt/rpm-hardlinks/standalone").permissions(0o644),
+    )?
+    .build()?;
+
+    std::fs::remove_dir_all(&temp_dir)?;
+
+    let mut buf = Vec::new();
+    pkg.write(&mut buf)?;
+    let parsed = Package::parse(&mut buf.as_slice())?;
+    let fixture = Package::open(common::pkgs::v6::RPM_HARDLINKS)?;
+    assert_packages_match(&parsed, &fixture, "v6")?;
+
+    Ok(())
+}
+
 /// Test that reading and writing RPM files is lossless.
 ///
 /// Parse all test fixture RPM files, write them out, and verify the checksum

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -388,6 +388,7 @@ fn test_hardlinks_package() -> Result<(), Box<dyn std::error::Error>> {
     ));
     assert!(matches!(metadata.get_vcs(), Err(Error::TagNotFound(_))));
 
+    // 6 files: alpha-1, alpha-2, alpha-3, beta-1, beta-2, standalone
     assert_eq!(metadata.get_file_entries()?.len(), 6);
     assert_eq!(metadata.get_file_paths()?.len(), 6);
     assert!(metadata.get_changelog_entries()?.is_empty());
@@ -406,16 +407,24 @@ fn test_hardlinks_package() -> Result<(), Box<dyn std::error::Error>> {
     assert!(metadata.get_enhances()?.is_empty());
     assert!(metadata.get_recommends()?.is_empty());
 
+    // Verify hardlink metadata via shared inodes.
     let inodes = metadata
         .header
         .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILEINODES)?;
+
+    // alpha-1, alpha-2, alpha-3 share an inode.
     assert_eq!(inodes[0], inodes[1]);
     assert_eq!(inodes[1], inodes[2]);
+
+    // beta-1, beta-2 share a different inode.
     assert_eq!(inodes[3], inodes[4]);
     assert_ne!(inodes[3], inodes[0]);
+
+    // standalone has its own inode.
     assert_ne!(inodes[5], inodes[0]);
     assert_ne!(inodes[5], inodes[3]);
 
+    // Signature checksums (v6 package).
     assert_eq!(
         metadata
             .signature
@@ -428,6 +437,7 @@ fn test_hardlinks_package() -> Result<(), Box<dyn std::error::Error>> {
             .get_entry_data_as_string(IndexSignatureTag::RPMSIGTAG_SHA3_256)?,
         "4422ac5a772b85bad8febeeac2850506805f9e7a0c07ea2e2d56d71d3c2b5557"
     );
+    // Payload digest.
     assert_eq!(
         metadata
             .header

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -345,6 +345,99 @@ fn test_file_types() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Parse the rpm-hardlinks fixture and verify its hardlink metadata.
+#[test]
+fn test_hardlinks_package() -> Result<(), Box<dyn std::error::Error>> {
+    let package = Package::open(common::pkgs::v6::RPM_HARDLINKS)?;
+    let metadata = &package.metadata;
+
+    assert!(!metadata.is_source_package());
+    assert_eq!(metadata.get_name()?, "rpm-hardlinks");
+    assert!(matches!(metadata.get_epoch(), Err(Error::TagNotFound(_))));
+    assert_eq!(metadata.get_version()?, "1.0");
+    assert_eq!(metadata.get_release()?, "1");
+    assert_eq!(metadata.get_arch()?, "noarch");
+    assert_eq!(
+        metadata.get_description()?,
+        "A package for exercising RPM hard link handling in the payload.\n\
+         Contains sets of hard-linked files to test inode deduplication\n\
+         and the RPMTAG_FILEINODES / RPMTAG_FILENLINKS tags."
+    );
+    assert_eq!(metadata.get_summary()?, "Test RPM hard link handling");
+    assert_eq!(metadata.get_license()?, "MIT");
+    assert_eq!(metadata.get_group()?, "Unspecified");
+    assert_eq!(metadata.get_build_host()?, "localhost");
+    assert_eq!(
+        metadata.get_build_time()?,
+        common::FIXTURE_SOURCE_DATE as u64
+    );
+    assert_eq!(metadata.get_payload_compressor()?, CompressionType::None);
+    assert_eq!(metadata.get_installed_size()?, 52);
+    assert_eq!(metadata.get_cookie()?, COOKIE);
+    assert_eq!(metadata.get_source_rpm()?, "rpm-hardlinks-1.0-1.src.rpm");
+    assert_eq!(
+        metadata.get_file_digest_algorithm()?,
+        DigestAlgorithm::Sha2_256
+    );
+
+    assert!(matches!(metadata.get_vendor(), Err(Error::TagNotFound(_))));
+    assert!(matches!(metadata.get_url(), Err(Error::TagNotFound(_))));
+    assert!(matches!(
+        metadata.get_packager(),
+        Err(Error::TagNotFound(_))
+    ));
+    assert!(matches!(metadata.get_vcs(), Err(Error::TagNotFound(_))));
+
+    assert_eq!(metadata.get_file_entries()?.len(), 6);
+    assert_eq!(metadata.get_file_paths()?.len(), 6);
+    assert!(metadata.get_changelog_entries()?.is_empty());
+    assert_eq!(
+        metadata.get_provides()?,
+        vec![Dependency::eq("rpm-hardlinks", "1.0-1")]
+    );
+    assert_eq!(
+        metadata.get_requires()?,
+        vec![Dependency::rpmlib("LargeFiles", "4.12.0-1")]
+    );
+    assert!(metadata.get_conflicts()?.is_empty());
+    assert!(metadata.get_obsoletes()?.is_empty());
+    assert!(metadata.get_supplements()?.is_empty());
+    assert!(metadata.get_suggests()?.is_empty());
+    assert!(metadata.get_enhances()?.is_empty());
+    assert!(metadata.get_recommends()?.is_empty());
+
+    let inodes = metadata
+        .header
+        .get_entry_data_as_u32_array(IndexTag::RPMTAG_FILEINODES)?;
+    assert_eq!(inodes[0], inodes[1]);
+    assert_eq!(inodes[1], inodes[2]);
+    assert_eq!(inodes[3], inodes[4]);
+    assert_ne!(inodes[3], inodes[0]);
+    assert_ne!(inodes[5], inodes[0]);
+    assert_ne!(inodes[5], inodes[3]);
+
+    assert_eq!(
+        metadata
+            .signature
+            .get_entry_data_as_string(IndexSignatureTag::RPMSIGTAG_SHA256)?,
+        "83eb72fe3720ae2b4696da421d5cc34ef0acd66543b71746e9a13954c77fe7a4"
+    );
+    assert_eq!(
+        metadata
+            .signature
+            .get_entry_data_as_string(IndexSignatureTag::RPMSIGTAG_SHA3_256)?,
+        "4422ac5a772b85bad8febeeac2850506805f9e7a0c07ea2e2d56d71d3c2b5557"
+    );
+    assert_eq!(
+        metadata
+            .header
+            .get_entry_data_as_string_array(IndexTag::RPMTAG_PAYLOADSHA256)?,
+        vec!["46b58e9fa6f9b7db79738203322df03612f439053140a5aefa9f1b3654db9a20"]
+    );
+
+    Ok(())
+}
+
 /// Parse v4 and v6 rpm-basic fixtures and verify metadata fields.
 #[test]
 fn test_basic_package() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Problem

`PackageBuilder` cannot currently express caller-owned hardlink topology. Inferring topology from source filesystem device/inode values, as explored in #354, does not cover generated bytes or callers that already hold an exact package-local identity.

## Change

- add `FileOptionsBuilder::hardlink(identity)` for regular payload members
- validate that each identity is complete and that member content and effective metadata agree
- isolate hardlink planning in a focused builder module
- emit shared header inode/device authority and CPIO link counts
- follow librpm archive semantics: ordinary entries first, hardlink sets after them, and bytes only on the completing member
- count hardlinked content once in installed-size authority

## Proof

- `cargo test --test building explicit_hardlink -- --nocapture` (2 passed)
- `cargo test` reached 116 passing tests; 11 signing tests then failed because generated signed RPM fixtures are absent from a fresh clone
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The all-target Clippy baseline also currently reports four Rust 1.97 lints in untouched tests/examples.

Refs #332 and #354.