### PR TITLE
Fix header paths for root-child directory entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Explicit root-child entries such as `/usr` now use `/` as their RPM header dirname instead of `//`.
+
 ### Added
 
 - The optional `signature-sequoia` feature provides OpenPGP signing and verification through Sequoia 2.3's pure-Rust crypto backend. Signature backends are mutually exclusive: select Sequoia with `--no-default-features --features signature-sequoia`. The default remains `signature-pgp`, including its draft-PQC support.

--- a/src/rpm/builder.rs
+++ b/src/rpm/builder.rs
@@ -921,16 +921,25 @@ impl PackageBuilder {
             desc: "no parent directory found",
         })?;
 
+        let root_child = matches!(parent.to_str(), Some("/" | "."));
         let (cpio_path, dir) = if normalized.starts_with('.') {
             (
                 normalized.to_string(),
                 // strip_prefix() should never fail because we've checked the special cases already
-                format!("/{}/", parent.strip_prefix(".").unwrap().to_string_lossy()),
+                if root_child {
+                    "/".to_string()
+                } else {
+                    format!("/{}/", parent.strip_prefix(".").unwrap().to_string_lossy())
+                },
             )
         } else {
             (
                 format!(".{}", normalized),
-                format!("{}/", parent.to_string_lossy()),
+                if root_child {
+                    "/".to_string()
+                } else {
+                    format!("{}/", parent.to_string_lossy())
+                },
             )
         };
 

--- a/tests/building.rs
+++ b/tests/building.rs
@@ -409,6 +409,39 @@ fn test_build_with_new_file_api() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[test]
+fn root_child_directories_use_canonical_header_and_payload_paths()
+-> Result<(), Box<dyn std::error::Error>> {
+    let pkg = PackageBuilder::new(
+        "root-child-directories",
+        "1.0.0",
+        "MIT",
+        "x86_64",
+        "root child directory paths",
+    )
+    .with_dir_entry(FileOptions::dir("/usr").permissions(0o755))?
+    .with_dir_entry(FileOptions::dir("./opt").permissions(0o750))?
+    .build()?;
+
+    let entries = pkg.metadata.get_file_entries()?;
+    assert_eq!(entries.len(), 2);
+    for (path, basename, permissions) in [("/opt", "opt", 0o750), ("/usr", "usr", 0o755)] {
+        let entry = entries
+            .iter()
+            .find(|entry| entry.path() == Path::new(path))
+            .unwrap_or_else(|| panic!("missing {path}"));
+        assert_eq!(entry.dirname(), "/");
+        assert_eq!(entry.basename(), basename);
+        assert_eq!(entry.permissions(), permissions);
+    }
+
+    let payload = pkg.files()?.collect::<Result<Vec<_>, _>>()?;
+    assert_eq!(payload.len(), 2);
+    assert_eq!(payload[0].metadata.path(), Path::new("/opt"));
+    assert_eq!(payload[1].metadata.path(), Path::new("/usr"));
+    Ok(())
+}
+
 /// Verify that `with_dir` recursively adds directory entries and files.
 #[test]
 fn test_with_dir_basic() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Problem

`PackageBuilder::with_dir_entry(FileOptions::dir("/usr"))` derives `/` as the parent and then appends another slash, producing `RPMTAG_DIRNAMES = ["//"]`. Consumers reconstruct that as the noncanonical path `//usr`; the same defect affects `./opt`.

## Fix

Treat `/` and `.` parents as the RPM root dirname `/`. Descendant splitting is unchanged.

The regression test verifies both absolute and dot-relative root children through:

- exact dirname and basename header authority
- mode preservation
- the payload CPIO iterator

## Verification

- `cargo test --test building -- --nocapture` (26 passed)
- `cargo clippy --lib -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

Discovered while fixing ConaryLabs/Conary#464.